### PR TITLE
Moved Variable class to namespace

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,11 +17,12 @@ engines:
     checks:
       CleanCode/StaticAccess:
         enabled: false
-      Controversial/CamelCasePropertyName:
-        enabled: false
       Controversial/CamelCaseParameterName:
         enabled: false
-
+      Controversial/CamelCasePropertyName:
+        enabled: false
+      Controversial/CamelCaseVariableName:
+        enabled: false
 ratings:
   paths:
     - "**.php"

--- a/.idea/php-assertion.iml
+++ b/.idea/php-assertion.iml
@@ -2,8 +2,8 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Fleshgrinder\Assertion\" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Fleshgrinder\Assertion\" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Fleshgrinder\Assertions\" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Fleshgrinder\Assertions\" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "scrutinizer/ocular": "^1.3"
     },
     "suggest": {
-        "ext-gmp": "For asserting big integer numbers.",
         "ext-bcmath": "For asserting arbitrary precision numbers."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,22 @@
         "ext-bcmath": "For asserting arbitrary precision numbers."
     },
     "autoload": {
-		"psr-4": {
-			"Fleshgrinder\\Assertion\\": "src/"
-		},
 		"classmap": [
-			"src/Variable.php"
-		]
+			"src/BackwardsCompatibility/Variable.php"
+		],
+		"psr-4": {
+			"Fleshgrinder\\Assertions\\": [
+				"src/",
+				"tests/"
+			]
+		}
     },
     "autoload-dev": {
+		"classmap": [
+			"src/BackwardsCompatibility/Variable.php"
+		],
         "psr-4": {
-            "Fleshgrinder\\Assertion\\": [
+            "Fleshgrinder\\Assertions\\": [
 				"src/",
 				"tests/"
 			]

--- a/src/BackwardsCompatibility/Variable.php
+++ b/src/BackwardsCompatibility/Variable.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * This class is for backwards compatibility only. It would also be possible to
+ * use the {@see \class_alias} function, however, static code analysis tools,
+ * like the one built-in into IDEs, will not recognize the class and display
+ * errors. Hence, it is better to use an actual class.
+ */
+abstract class Variable extends Fleshgrinder\Assertions\Variable {
+
+	// Intentionally left blank.
+
+}

--- a/src/BackwardsCompatibility/Variable.php
+++ b/src/BackwardsCompatibility/Variable.php
@@ -1,5 +1,7 @@
 <?php
 
+// @codingStandardsIgnoreStart
+
 /**
  * This class is for backwards compatibility only. It would also be possible to
  * use the {@see \class_alias} function, however, static code analysis tools,
@@ -11,3 +13,5 @@ abstract class Variable extends Fleshgrinder\Assertions\Variable {
 	// Intentionally left blank.
 
 }
+
+// @codingStandardsIgnoreEnd

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -664,14 +664,21 @@ abstract class Variable {
 	 * @return bool
 	 */
 	final public static function isSubclassOf($var, $class, $allow_string = true) {
-		assert('is_object($class) || is_string($class)', 'second argument must be of type object or string');
+		assert('is_object($class) || (is_string($class) && class_exists($class))', 'second argument must be an object or the name of an existing class');
 		assert('is_bool($allow_string)', 'third argument must be of type bool');
 
-		if (is_object($class)) {
-			$class = get_class($class);
+		$str = \is_string($var);
+
+		if (\is_object($var) === \false && $str === \false) {
+			return \false;
 		}
 
-		return is_subclass_of($var, $class, $allow_string);
+		if ($str && ($allow_string === \false || \class_exists($var) === \false)) {
+			return \false;
+		}
+
+		/** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+		return (new \ReflectionClass($var))->isSubclassOf(new \ReflectionClass($class));
 	}
 
 	/**
@@ -730,13 +737,7 @@ abstract class Variable {
 		}, E_WARNING);
 
 		try {
-			$gmp = gmp_init($number);
-
-			if (gmp_strval($gmp) !== $number) {
-				return false;
-			}
-
-			return $gmp;
+			return gmp_init($number);
 		}
 		catch (\ErrorException $e) {
 			return false;

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -181,7 +181,7 @@ abstract class Variable {
 	}
 
 	/**
-	 * Assert variable contains integers (ℤ) only, asserts big numbers with {@see GMP}.
+	 * Assert variable contains integers (ℤ) only.
 	 *
 	 * @link https://secure.php.net/integer
 	 * @see isInteger()
@@ -208,7 +208,7 @@ abstract class Variable {
 	 *
 	 * @see array_key_exists()
 	 * @param mixed $var
-	 * @param string[] ...$keys
+	 * @param string[] $keys
 	 * @return bool
 	 */
 	final public static function hasKeys($var, ...$keys) {
@@ -224,7 +224,7 @@ abstract class Variable {
 	}
 
 	/**
-	 * Assert variable contains natural numbers (ℕ₀) only, asserts big numbers with {@see GMP}.
+	 * Assert variable contains natural numbers (ℕ₀) only.
 	 *
 	 * @link https://secure.php.net/integer
 	 * @see isNaturalNumber()
@@ -272,7 +272,7 @@ abstract class Variable {
 	}
 
 	/**
-	 * Assert variable contains positive natural numbers (ℕ₁) only, asserts big numbers with {@see GMP}.
+	 * Assert variable contains positive natural numbers (ℕ₁) only.
 	 *
 	 * @link https://secure.php.net/integer
 	 * @see isPositiveNaturalNumber()
@@ -463,20 +463,18 @@ abstract class Variable {
 	}
 
 	/**
-	 * Assert variable is an integer (ℤ), asserts big numbers with {@see GMP} if available. This method triggers
-	 * an error of severity `E_USER_NOTICE` if GMP is not installed.
+	 * Assert variable is an integer (ℤ).
 	 *
 	 * @lnk https://secure.php.net/integer
 	 * @param mixed $var
 	 * @return bool
 	 */
 	final public static function isInteger($var) {
-		return !is_bool($var) && !is_float($var) && \filter_var($var, \FILTER_VALIDATE_INT) !== \false || static::matches($var, '/^(?:\+|-)?[1-9]\d*$/D');
+		return !is_bool($var) && !is_float($var) && (\filter_var($var, \FILTER_VALIDATE_INT) !== \false || static::matches($var, '/^(?:\+|-)?(?:[1-9]\d*|0[0-7]*|0b[01]*|0x[\da-f]*)$/Di'));
 	}
 
 	/**
-	 * Assert variable is a natural number (ℕ₀), asserts big numbers with {@see GMP} if available. This method triggers
-	 * an error of severity `E_USER_NOTICE` if GMP is not installed.
+	 * Assert variable is a natural number (ℕ₀).
 	 *
 	 * @lnk https://secure.php.net/integer
 	 * @param mixed $var
@@ -487,8 +485,7 @@ abstract class Variable {
 	}
 
 	/**
-	 * Assert variable is a natural number (ℕ₀), asserts big numbers with {@see GMP} if available. This method triggers
-	 * an error of severity `E_USER_NOTICE` if GMP is not installed.
+	 * Assert variable is a natural number (ℕ₀).
 	 *
 	 * @lnk https://secure.php.net/integer
 	 * @param mixed $var

--- a/tests/ApplyCallbackTest.php
+++ b/tests/ApplyCallbackTest.php
@@ -5,13 +5,11 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
-
-use Variable;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ApplyCallbackTest extends VariableDataTypeTest {
 

--- a/tests/ApplyCallbackTest.php
+++ b/tests/ApplyCallbackTest.php
@@ -13,7 +13,7 @@ namespace Fleshgrinder\Assertions;
  */
 final class ApplyCallbackTest extends VariableDataTypeTest {
 
-	public function testWithDelta() {
+	public static function testWithDelta() {
 		$correctly_called = 0;
 		$data = ['a', 'b'];
 		Variable::applyCallback($data, function ($member, $delta) use (&$correctly_called, $data) {
@@ -21,10 +21,16 @@ final class ApplyCallbackTest extends VariableDataTypeTest {
 				++$correctly_called;
 			}
 		});
-		$this->assertSame(2, $correctly_called);
+		static::assertSame(2, $correctly_called);
 	}
 
-	public function testWithoutDelta() {
+	public static function testWithDeltaFailure() {
+		static::assertFalse(Variable::applyCallback([1], function () {
+			return \false;
+		}));
+	}
+
+	public static function testWithoutDelta() {
 		$correctly_called = 0;
 		$data = ['a', 'b'];
 		$i = 0;
@@ -33,7 +39,13 @@ final class ApplyCallbackTest extends VariableDataTypeTest {
 				++$correctly_called;
 			}
 		}, false);
-		$this->assertSame(2, $correctly_called);
+		static::assertSame(2, $correctly_called);
+	}
+
+	public static function testWithoutDeltaFailure() {
+		static::assertFalse(Variable::applyCallback([1], function () {
+			return \false;
+		}), \false);
 	}
 
 	/** @dataProvider dataProviderDataTypes */

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -24,4 +24,18 @@ final class ArrayTest extends VariableTest {
 		return ['empty_array', 'array', 'dictionary', 'callable_method'];
 	}
 
+	/**
+	 * @covers \Fleshgrinder\Assertions\Variable::hasAllSet()
+	 */
+	public static function testHasAllSet() {
+		static::assertTrue(Variable::hasAllSet([1, 2, 3]));
+	}
+
+	/**
+	 * @covers \Fleshgrinder\Assertions\Variable::hasAllSet()
+	 */
+	public static function testHasAllSetWithUnset() {
+		static::assertFalse(Variable::hasAllSet([1, \null, 3]));
+	}
+
 }

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasArraysOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasArraysOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ArrayTest extends VariableTest {
 

--- a/tests/BoolTest.php
+++ b/tests/BoolTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasBoolsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasBoolsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class BoolTest extends VariableTest {
 

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasCallablesOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasCallablesOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class CallableTest extends VariableTest {
 

--- a/tests/ContainsTest.php
+++ b/tests/ContainsTest.php
@@ -5,15 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
-
-use Variable;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::allContain()
- * @covers \Variable::contains()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::allContain()
+ * @covers \Fleshgrinder\Assertions\Variable::contains()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ContainsTest extends VariableDataTypeTest {
 

--- a/tests/DisableDeprecationErrors.php
+++ b/tests/DisableDeprecationErrors.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 trait DisableDeprecationErrors {
 

--- a/tests/FloatTest.php
+++ b/tests/FloatTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasFloatsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasFloatsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class FloatTest extends VariableTest {
 

--- a/tests/InstanceOfTest.php
+++ b/tests/InstanceOfTest.php
@@ -5,17 +5,17 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 final class InstanceOfTestHelperClass {}
 
-use Variable;
+use Fleshgrinder\Assertions\Variable;
 
 /**
- * @covers \Variable::hasInstancesOfOnly()
- * @covers \Variable::isInstanceOf()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasInstancesOfOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isInstanceOf()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class InstanceOfTest extends VariableDataTypeTest {
 

--- a/tests/InstanceOfTest.php
+++ b/tests/InstanceOfTest.php
@@ -7,10 +7,6 @@
 
 namespace Fleshgrinder\Assertions;
 
-final class InstanceOfTestHelperClass {}
-
-use Fleshgrinder\Assertions\Variable;
-
 /**
  * @covers \Fleshgrinder\Assertions\Variable::hasInstancesOfOnly()
  * @covers \Fleshgrinder\Assertions\Variable::isInstanceOf()
@@ -31,23 +27,39 @@ final class InstanceOfTest extends VariableDataTypeTest {
 
 	/** @dataProvider dataProviderDataTypes */
 	public function testAllDataTypes($var) {
-		$this->assertFalse(Variable::hasInstancesOfOnly($var, '\stdClass'));
+		static::assertFalse(Variable::isInstanceOf($var, \stdClass::class));
 	}
 
-	public function testInstance() {
-		$this->assertTrue(Variable::hasInstancesOfOnly([new InstanceOfTestHelperClass()], new InstanceOfTestHelperClass(), false));
+	public static function testInstance() {
+		static::assertTrue(Variable::isInstanceOf(new InstanceOfTestHelperClass, new InstanceOfTestHelperClass, false));
 	}
 
-	public function testString() {
-		$this->assertTrue(Variable::hasInstancesOfOnly([InstanceOfTestHelperClass::class], InstanceOfTestHelperClass::class));
+	public static function testAllInstances() {
+		static::assertTrue(Variable::hasInstancesOfOnly([new InstanceOfTestHelperClass], new InstanceOfTestHelperClass, false));
 	}
 
-	public function testNotInstance() {
-		$this->assertFalse(Variable::hasInstancesOfOnly([new InstanceOfTestHelperClass()], $this, false));
+	public static function testString() {
+		static::assertTrue(Variable::isInstanceOf(InstanceOfTestHelperClass::class, InstanceOfTestHelperClass::class));
 	}
 
-	public function testNotString() {
-		$this->assertFalse(Variable::hasInstancesOfOnly([InstanceOfTestHelperClass::class], static::class, true));
+	public static function testAllStrings() {
+		static::assertTrue(Variable::hasInstancesOfOnly([InstanceOfTestHelperClass::class], InstanceOfTestHelperClass::class));
+	}
+
+	public static function testNotInstance() {
+		static::assertFalse(Variable::isInstanceOf(new InstanceOfTestHelperClass, new \DateTIme, false));
+	}
+
+	public static function testAllNotInstances() {
+		static::assertFalse(Variable::hasInstancesOfOnly([new InstanceOfTestHelperClass], new \DateTIme, false));
+	}
+
+	public static function testNotString() {
+		static::assertFalse(Variable::isInstanceOf(InstanceOfTestHelperClass::class, static::class, true));
+	}
+
+	public static function testAllNotStrings() {
+		static::assertFalse(Variable::hasInstancesOfOnly([InstanceOfTestHelperClass::class], static::class, true));
 	}
 
 }

--- a/tests/InstanceOfTestHelperClass.php
+++ b/tests/InstanceOfTestHelperClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Fleshgrinder\Assertions;
+
+final class InstanceOfTestHelperClass {
+
+	// Intentionally left blank.
+
+}

--- a/tests/IntTest.php
+++ b/tests/IntTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasIntsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasIntsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class IntTest extends VariableTest {
 

--- a/tests/IntegerTest.php
+++ b/tests/IntegerTest.php
@@ -5,15 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::gmpCreate()
- * @covers \Variable::hasIntegersOnly()
- * @covers \Variable::isInteger()
- * @covers \Variable::setWarningHandler()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
+ * @covers \Fleshgrinder\Assertions\Variable::hasIntegersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isInteger()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class IntegerTest extends VariableTest {
 

--- a/tests/IntegerTest.php
+++ b/tests/IntegerTest.php
@@ -8,11 +8,11 @@
 namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
  * @covers \Fleshgrinder\Assertions\Variable::hasIntegersOnly()
  * @covers \Fleshgrinder\Assertions\Variable::isInteger()
  * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
  * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
+ * @uses \Fleshgrinder\Assertions\Variable::matches()
  */
 final class IntegerTest extends VariableTest {
 

--- a/tests/IterableTest.php
+++ b/tests/IterableTest.php
@@ -5,11 +5,11 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasIterablesOnly()
- * @uses \Variable::applyCallback()
+ * @covers \Fleshgrinder\Assertions\Variable::hasIterablesOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
  */
 final class IterableTest extends VariableTest {
 

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -5,12 +5,10 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
-
-use Variable;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasKeys()
+ * @covers \Fleshgrinder\Assertions\Variable::hasKeys()
  */
 final class KeyTest extends VariableDataTypeTest {
 

--- a/tests/MatchesTest.php
+++ b/tests/MatchesTest.php
@@ -5,15 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
-
-use Variable;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::allMatch()
- * @covers \Variable::matches()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::allMatch()
+ * @covers \Fleshgrinder\Assertions\Variable::matches()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class MatchesTest extends VariableDataTypeTest {
 

--- a/tests/NaturalNumberTest.php
+++ b/tests/NaturalNumberTest.php
@@ -5,15 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::gmpCreate()
- * @covers \Variable::hasNaturalNumbersOnly()
- * @covers \Variable::isNaturalNumber()
- * @covers \Variable::setWarningHandler()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
+ * @covers \Fleshgrinder\Assertions\Variable::hasNaturalNumbersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isNaturalNumber()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class NaturalNumberTest extends VariableTest {
 

--- a/tests/NaturalNumberTest.php
+++ b/tests/NaturalNumberTest.php
@@ -8,11 +8,12 @@
 namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
  * @covers \Fleshgrinder\Assertions\Variable::hasNaturalNumbersOnly()
  * @covers \Fleshgrinder\Assertions\Variable::isNaturalNumber()
  * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isInteger()
  * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
+ * @uses \Fleshgrinder\Assertions\Variable::matches()
  */
 final class NaturalNumberTest extends VariableTest {
 

--- a/tests/NotEmptyTest.php
+++ b/tests/NotEmptyTest.php
@@ -5,14 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
  * This test illustrates nicely how dangerous PHP’s {@see empty} is if the caller does not know what he really wants.
  *
- * @covers \Variable::hasNoEmptyValues()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasNoEmptyValues()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class NotEmptyTest extends VariableTest {
 

--- a/tests/NumericTest.php
+++ b/tests/NumericTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasNumericsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasNumericsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class NumericTest extends VariableTest {
 

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasObjectsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasObjectsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ObjectTest extends VariableTest {
 

--- a/tests/PositiveNaturalNumberTest.php
+++ b/tests/PositiveNaturalNumberTest.php
@@ -8,11 +8,12 @@
 namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
  * @covers \Fleshgrinder\Assertions\Variable::hasPositiveNaturalNumbersOnly()
  * @covers \Fleshgrinder\Assertions\Variable::isPositiveNaturalNumber()
  * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isInteger()
  * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
+ * @uses \Fleshgrinder\Assertions\Variable::matches()
  */
 final class PositiveNaturalNumberTest extends VariableTest {
 

--- a/tests/PositiveNaturalNumberTest.php
+++ b/tests/PositiveNaturalNumberTest.php
@@ -5,15 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::gmpCreate()
- * @covers \Variable::hasPositiveNaturalNumbersOnly()
- * @covers \Variable::isPositiveNaturalNumber()
- * @covers \Variable::setWarningHandler()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::gmpCreate()
+ * @covers \Fleshgrinder\Assertions\Variable::hasPositiveNaturalNumbersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isPositiveNaturalNumber()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class PositiveNaturalNumberTest extends VariableTest {
 

--- a/tests/RealNumberTest.php
+++ b/tests/RealNumberTest.php
@@ -5,14 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasRealNumbersOnly()
- * @covers \Variable::isRealNumber()
- * @covers \Variable::isScalarNaturalNumber()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasRealNumbersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isRealNumber()
+ * @covers \Fleshgrinder\Assertions\Variable::isScalarNaturalNumber()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class RealNumberTest extends VariableTest {
 

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasResourcesOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasResourcesOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ResourceTest extends VariableTest {
 

--- a/tests/ScalarNaturalNumberTest.php
+++ b/tests/ScalarNaturalNumberTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasScalarNaturalNumbersOnly()
- * @covers \Variable::isScalarNaturalNumber()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasScalarNaturalNumbersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isScalarNaturalNumber()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ScalarNaturalNumberTest extends VariableTest {
 

--- a/tests/ScalarPositiveNaturalNumberTest.php
+++ b/tests/ScalarPositiveNaturalNumberTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasScalarPositiveNaturalNumbersOnly()
- * @covers \Variable::isScalarPositiveNaturalNumber()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasScalarPositiveNaturalNumbersOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isScalarPositiveNaturalNumber()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ScalarPositiveNaturalNumberTest extends VariableTest {
 

--- a/tests/ScalarTest.php
+++ b/tests/ScalarTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasScalarsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasScalarsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class ScalarTest extends VariableTest {
 

--- a/tests/StreamResourceTest.php
+++ b/tests/StreamResourceTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStreamResourcesOnly()
- * @covers \Variable::isStreamResource()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStreamResourcesOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isStreamResource()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StreamResourceTest extends VariableTest {
 

--- a/tests/StrictArrayTest.php
+++ b/tests/StrictArrayTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStrictArraysOnly()
- * @covers \Variable::isStrictArray()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStrictArraysOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isStrictArray()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StrictArrayTest extends VariableTest {
 

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStringsOnly()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStringsOnly()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StringTest extends VariableTest {
 

--- a/tests/Stringable.php
+++ b/tests/Stringable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Fleshgrinder\Assertions;
+
+final class Stringable {
+
+	private $string;
+
+	public function __construct($string) {
+		$this->string = $string;
+	}
+
+	public function __toString() {
+		return (string) $this->string;
+	}
+
+}

--- a/tests/StringableTest.php
+++ b/tests/StringableTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStringablesOnly()
- * @covers \Variable::isStringable()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStringablesOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isStringable()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StringableTest extends VariableTest {
 

--- a/tests/StringableWithContentTest.php
+++ b/tests/StringableWithContentTest.php
@@ -5,14 +5,14 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStringablesWithContentOnly()
- * @covers \Variable::isStringable()
- * @covers \Variable::isStringableWithContent()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStringablesWithContentOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isStringable()
+ * @covers \Fleshgrinder\Assertions\Variable::isStringableWithContent()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StringableWithContentTest extends VariableTest {
 

--- a/tests/StringsWithContentTest.php
+++ b/tests/StringsWithContentTest.php
@@ -5,13 +5,13 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasStringsWithContentOnly()
- * @covers \Variable::isStringWithContent()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasStringsWithContentOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isStringWithContent()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class StringsWithContentTest extends VariableTest {
 

--- a/tests/SubclassTest.php
+++ b/tests/SubclassTest.php
@@ -5,19 +5,19 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 class SubclassTestParentClass {}
 
 final class SubclassTestChildClass extends SubclassTestParentClass {}
 
-use Variable;
+use Fleshgrinder\Assertions\Variable;
 
 /**
- * @covers \Variable::hasSubclassesOfOnly()
- * @covers \Variable::isSubclassOf()
- * @uses \Variable::applyCallback()
- * @uses \Variable::isTraversable()
+ * @covers \Fleshgrinder\Assertions\Variable::hasSubclassesOfOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isSubclassOf()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
+ * @uses \Fleshgrinder\Assertions\Variable::isTraversable()
  */
 final class SubclassTest extends VariableDataTypeTest {
 

--- a/tests/TraversableTest.php
+++ b/tests/TraversableTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 /**
- * @covers \Variable::hasTraversablesOnly()
- * @covers \Variable::isTraversable()
- * @uses \Variable::applyCallback()
+ * @covers \Fleshgrinder\Assertions\Variable::hasTraversablesOnly()
+ * @covers \Fleshgrinder\Assertions\Variable::isTraversable()
+ * @uses \Fleshgrinder\Assertions\Variable::applyCallback()
  */
 final class TraversableTest extends VariableTest {
 	use DisableDeprecationErrors;

--- a/tests/VariableDataTypeTest.php
+++ b/tests/VariableDataTypeTest.php
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
+namespace Fleshgrinder\Assertions;
 
 use ArrayObject;
 use PHPUnit_Framework_TestCase;
 use SplFixedArray;
-use Variable;
+use Fleshgrinder\Assertions\Variable;
 
 final class Stringable {
 

--- a/tests/VariableDataTypeTest.php
+++ b/tests/VariableDataTypeTest.php
@@ -7,26 +7,7 @@
 
 namespace Fleshgrinder\Assertions;
 
-use ArrayObject;
-use PHPUnit_Framework_TestCase;
-use SplFixedArray;
-use Fleshgrinder\Assertions\Variable;
-
-final class Stringable {
-
-	private $string;
-
-	public function __construct($string) {
-		$this->string = $string;
-	}
-
-	public function __toString() {
-		return $this->string;
-	}
-
-}
-
-abstract class VariableDataTypeTest extends PHPUnit_Framework_TestCase {
+abstract class VariableDataTypeTest extends \PHPUnit_Framework_TestCase {
 
 	/** @var array */
 	protected static $data_types;
@@ -103,10 +84,10 @@ abstract class VariableDataTypeTest extends PHPUnit_Framework_TestCase {
 				'object'                     => [[(object) []]],
 				'empty_stringable'           => [[new Stringable('')]],
 				'stringable'                 => [[new Stringable('PHP')]],
-				'empty_array_object'         => [[new ArrayObject([])]],
-				'array_object'               => [[new ArrayObject([0, 1, 2, 3, 4])]],
-				'empty_fixed_array'          => [[new SplFixedArray()]],
-				'fixed_array'                => [[SplFixedArray::fromArray([0, 1, 2, 3, 4])]],
+				'empty_array_object'         => [[new \ArrayObject([])]],
+				'array_object'               => [[new \ArrayObject([0, 1, 2, 3, 4])]],
+				'empty_fixed_array'          => [[new \SplFixedArray()]],
+				'fixed_array'                => [[\SplFixedArray::fromArray([0, 1, 2, 3, 4])]],
 				// callable
 				'closure'                    => [[function(){}]],
 				'callable_method'            => [[[new Stringable(''), '__toString']]],

--- a/tests/VariableTest.php
+++ b/tests/VariableTest.php
@@ -5,9 +5,7 @@
  * @license MIT
  */
 
-namespace Fleshgrinder\Assertion;
-
-use Variable;
+namespace Fleshgrinder\Assertions;
 
 abstract class VariableTest extends VariableDataTypeTest {
 


### PR DESCRIPTION
Backwards compatibility is provided through a separate Variable class in the
root namespace which extends Fleshgrinder\Assertions\Variable. This ensures
highest compatibility with all tools out there.

Closes #1 